### PR TITLE
fix: fix url get cat image with new json response

### DIFF
--- a/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
+++ b/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
@@ -14,7 +14,9 @@ export function useCatImage ({ fact }) {
     fetch(`https://cataas.com/cat/says/${threeFirstWords}?size=50&color=red&json=true`)
       .then(res => res.json())
       .then(response => {
-        const { url } = response
+        // const { url } = response
+        const { _id } = response
+        const url = `/cat/${_id}/says/${threeFirstWords}`
         setImageUrl(url)
       })
   }, [fact])


### PR DESCRIPTION
@midudev  :+1: This PR looks great - it's ready to merge! :shipit:

- [x] [cat json url](https://cataas.com/cat?json=true) no longer sends **url field**, instead it sends just a **_id field** 
- [ ] **TODO**: There are a problem that I was not able to fix: first time **fact** is empty and inside console there are a message: `GET https://cataas.comundefined/ net::ERR_NAME_NOT_RESOLVED` 