### PR TITLE
fix: (project 04) json trae imagen ha cambiado

### DIFF
--- a/projects/04-react-prueba-tecnica/package.json
+++ b/projects/04-react-prueba-tecnica/package.json
@@ -11,10 +11,10 @@
   "devDependencies": {
     "@playwright/test": "^1.30.0",
     "standard": "^17.0.0",
+    "@vitejs/plugin-react": "3.0.1",
     "vite": "^4.0.0"
   },
   "dependencies": {
-    "@vitejs/plugin-react": "3.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
+++ b/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
@@ -14,7 +14,8 @@ export function useCatImage ({ fact }) {
     fetch(`https://cataas.com/cat/says/${threeFirstWords}?size=50&color=red&json=true`)
       .then(res => res.json())
       .then(response => {
-        const { url } = response
+        const { _id } = response
+        const url = `/cat/${_id}/says/${threeFirstWords}`
         setImageUrl(url)
       })
   }, [fact])


### PR DESCRIPTION
@midudev  :+1: This PR looks great - it's ready to merge! :shipit:

04: [Fetching de datos - Custom Hooks - Testing con Playwright](https://www.youtube.com/watch?v=x-LcbVw99o8)
- [x] API [cat json url](https://cataas.com/cat?json=true) ya no envía campo  **url**,  en su lugar envía el campo **_id** a partir del cual se construye la **url** de la imagen, tal cual estaba originalmente.
- [ ] **TODO** 👁️ 👁️  : Hay un problema que no logré reparar: la primera vez que llama  **fact** está vacío y si vemos la consola tenemos el siguiente mensaje de error:  `GET https://cataas.comundefined/ net::ERR_NAME_NOT_RESOLVED` como se puede observar **useCatImage** está retornando un **imageUrl** undefined