### PR TITLE
Fix broken url for cat image (project 04)

### DIFF
--- a/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
+++ b/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
@@ -1,23 +1,26 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 
-const CAT_PREFIX_IMAGE_URL = 'https://cataas.com'
+const CAT_PREFIX_IMAGE_URL = "https://cataas.com";
 
-export function useCatImage ({ fact }) {
-  const [imageUrl, setImageUrl] = useState()
+export function useCatImage({ fact }) {
+  const [imageUrl, setImageUrl] = useState();
 
   // para recuperar la imagen cada vez que tenemos una cita nueva
   useEffect(() => {
-    if (!fact) return
+    if (!fact) return;
 
-    const threeFirstWords = fact.split(' ', 3).join(' ')
+    const threeFirstWords = fact.split(" ", 3).join(" ");
 
-    fetch(`https://cataas.com/cat/says/${threeFirstWords}?size=50&color=red&json=true`)
-      .then(res => res.json())
-      .then(response => {
-        const { url } = response
-        setImageUrl(url)
-      })
-  }, [fact])
+    fetch(
+      `https://cataas.com/cat/says/${threeFirstWords}?size=50&color=red&json=true`
+    )
+      .then((res) => res.json())
+      .then((response) => {
+        const { _id } = response;
+        const url = `/cat/${_id}/says/${threeFirstWords}`;
+        setImageUrl(url);
+      });
+  }, [fact]);
 
-  return { imageUrl: `${CAT_PREFIX_IMAGE_URL}${imageUrl}` }
+  return { imageUrl: `${CAT_PREFIX_IMAGE_URL}${imageUrl}` };
 }


### PR DESCRIPTION
@midudev  :+1: This PR looks great - it's ready to merge! :shipit:

04: [Fetching de datos - Custom Hooks - Testing con Playwright](https://www.youtube.com/watch?v=x-LcbVw99o8)
- [x] 🐱 [cat's json url](https://cataas.com/cat?json=true) no longer sends **url field**, instead it sends just a **_id field** 

**Before**
![Before](https://github.com/midudev/aprendiendo-react/assets/15000602/08268075-10e5-4caa-9306-6b74af971e27)

**After** 
![After](https://github.com/midudev/aprendiendo-react/assets/15000602/1f25b76f-d580-48df-930f-96710ddb6fa0)
