### PR TITLE
Fix broken url for cat's image (project 04)

### DIFF
--- a/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
+++ b/projects/04-react-prueba-tecnica/src/hooks/useCatImage.js
@@ -14,7 +14,8 @@ export function useCatImage ({ fact }) {
     fetch(`https://cataas.com/cat/says/${threeFirstWords}?size=50&color=red&json=true`)
       .then(res => res.json())
       .then(response => {
-        const { url } = response
+        const { _id } = response
+        const url = `/cat/${_id}/says/${threeFirstWords}`
         setImageUrl(url)
       })
   }, [fact])


### PR DESCRIPTION
@midudev  :+1: This PR looks great - it's ready to merge! :shipit:

- [x] [cat json url](https://cataas.com/cat?json=true) no longer sends **url field**, instead it sends just a **_id field** 

**Before** 

![Before](https://github.com/midudev/aprendiendo-react/assets/15000602/dbd8d593-1041-4321-9cff-2fbd3386c7e0)

**After**
![After](https://github.com/midudev/aprendiendo-react/assets/15000602/f4ea6d24-1750-43c7-b318-8cdb04ffd4e4)
