### PR TITLE
Remove border in .winner .win from index.css

### DIFF
--- a/projects/02-tic-tac-toe/src/index.css
+++ b/projects/02-tic-tac-toe/src/index.css
@@ -113,7 +113,6 @@ body {
 .winner .win {
   margin: 0 auto;
   width: fit-content;
-  border: 2px solid #eee;
   border-radius: 10px;
   display: flex;
   gap: 15px;


### PR DESCRIPTION
Lo he borrado para que ya no aparezca el "punto" blanco que se ve luego de la palabra "Empate". Se está renderizando el estilo del borde. y como buena QA, lo he quitado. :) También he revisado que este delete no afecte otros estilos, y no afecta, pero de todas formas, checkear.
![punto Empate](https://github.com/midudev/aprendiendo-react/assets/95765874/a7b41d03-40e3-44e6-8785-f6134a559373)
