### PR TITLE
Avoid translate of "Tic tac toe" in spanish App.jsx

### DIFF
--- a/projects/02-tic-tac-toe/src/App.jsx
+++ b/projects/02-tic-tac-toe/src/App.jsx
@@ -58,7 +58,7 @@ function App () {
 
   return (
     <main className='board'>
-      <h1>Tic tac toe</h1>
+      <h1 translate="no">Tic tac toe</h1>
       <button onClick={resetGame}>Reset del juego</button>
       <section className='game'>
         {


### PR DESCRIPTION
A pesar de tener en Layout.astro html lang="es", cuando el browser está en español, se traduce el título "Tic tac toe". He añadido translate="no" en App.jsx para evitar que esto ocurra :)
![translate ES](https://github.com/midudev/aprendiendo-react/assets/95765874/b942b73e-865e-40ea-a56c-ec9300929bb5)
