### PR TITLE
fix(06-shopping-cart): arregla json obsoleto

### DIFF
--- a/projects/06-shopping-cart/src/mocks/products.json
+++ b/projects/06-shopping-cart/src/mocks/products.json
@@ -1,559 +1,1606 @@
 {
-   "products": [
-   {
-   "id": 1,
-   "title": "iPhone 9",
-   "description": "An apple mobile which is nothing like apple",
-   "price": 549,
-   "discountPercentage": 12.96,
-   "rating": 4.69,
-   "stock": 94,
-   "brand": "Apple",
-   "category": "smartphones",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/1/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/1/1.jpg",
-   "https://cdn.dummyjson.com/product-images/1/2.jpg",
-   "https://cdn.dummyjson.com/product-images/1/3.jpg",
-   "https://cdn.dummyjson.com/product-images/1/4.jpg",
-   "https://cdn.dummyjson.com/product-images/1/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 2,
-   "title": "iPhone X",
-   "description": "SIM-Free, Model A19211 6.5-inch Super Retina HD display with OLED technology A12 Bionic chip with ...",
-   "price": 899,
-   "discountPercentage": 17.94,
-   "rating": 4.44,
-   "stock": 34,
-   "brand": "Apple",
-   "category": "smartphones",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/2/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/2/1.jpg",
-   "https://cdn.dummyjson.com/product-images/2/2.jpg",
-   "https://cdn.dummyjson.com/product-images/2/3.jpg",
-   "https://cdn.dummyjson.com/product-images/2/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 3,
-   "title": "Samsung Universe 9",
-   "description": "Samsung's new variant which goes beyond Galaxy to the Universe",
-   "price": 1249,
-   "discountPercentage": 15.46,
-   "rating": 4.09,
-   "stock": 36,
-   "brand": "Samsung",
-   "category": "smartphones",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/3/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/3/1.jpg"
-   ]
-   },
-   {
-   "id": 4,
-   "title": "OPPOF19",
-   "description": "OPPO F19 is officially announced on April 2021.",
-   "price": 280,
-   "discountPercentage": 17.91,
-   "rating": 4.3,
-   "stock": 123,
-   "brand": "OPPO",
-   "category": "smartphones",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/4/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/4/1.jpg",
-   "https://cdn.dummyjson.com/product-images/4/2.jpg",
-   "https://cdn.dummyjson.com/product-images/4/3.jpg",
-   "https://cdn.dummyjson.com/product-images/4/4.jpg",
-   "https://cdn.dummyjson.com/product-images/4/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 5,
-   "title": "Huawei P30",
-   "description": "Huawei’s re-badged P30 Pro New Edition was officially unveiled yesterday in Germany and now the device has made its way to the UK.",
-   "price": 499,
-   "discountPercentage": 10.58,
-   "rating": 4.09,
-   "stock": 32,
-   "brand": "Huawei",
-   "category": "smartphones",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/5/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/5/1.jpg",
-   "https://cdn.dummyjson.com/product-images/5/2.jpg",
-   "https://cdn.dummyjson.com/product-images/5/3.jpg"
-   ]
-   },
-   {
-   "id": 6,
-   "title": "MacBook Pro",
-   "description": "MacBook Pro 2021 with mini-LED display may launch between September, November",
-   "price": 1749,
-   "discountPercentage": 11.02,
-   "rating": 4.57,
-   "stock": 83,
-   "brand": "Apple",
-   "category": "laptops",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/6/thumbnail.png",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/6/1.png",
-   "https://cdn.dummyjson.com/product-images/6/2.jpg",
-   "https://cdn.dummyjson.com/product-images/6/3.png",
-   "https://cdn.dummyjson.com/product-images/6/4.jpg"
-   ]
-   },
-   {
-   "id": 7,
-   "title": "Samsung Galaxy Book",
-   "description": "Samsung Galaxy Book S (2020) Laptop With Intel Lakefield Chip, 8GB of RAM Launched",
-   "price": 1499,
-   "discountPercentage": 4.15,
-   "rating": 4.25,
-   "stock": 50,
-   "brand": "Samsung",
-   "category": "laptops",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/7/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/7/1.jpg",
-   "https://cdn.dummyjson.com/product-images/7/2.jpg",
-   "https://cdn.dummyjson.com/product-images/7/3.jpg",
-   "https://cdn.dummyjson.com/product-images/7/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 8,
-   "title": "Microsoft Surface Laptop 4",
-   "description": "Style and speed. Stand out on HD video calls backed by Studio Mics. Capture ideas on the vibrant touchscreen.",
-   "price": 1499,
-   "discountPercentage": 10.23,
-   "rating": 4.43,
-   "stock": 68,
-   "brand": "Microsoft Surface",
-   "category": "laptops",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/8/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/8/1.jpg",
-   "https://cdn.dummyjson.com/product-images/8/2.jpg",
-   "https://cdn.dummyjson.com/product-images/8/3.jpg",
-   "https://cdn.dummyjson.com/product-images/8/4.jpg",
-   "https://cdn.dummyjson.com/product-images/8/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 9,
-   "title": "Infinix INBOOK",
-   "description": "Infinix Inbook X1 Ci3 10th 8GB 256GB 14 Win10 Grey – 1 Year Warranty",
-   "price": 1099,
-   "discountPercentage": 11.83,
-   "rating": 4.54,
-   "stock": 96,
-   "brand": "Infinix",
-   "category": "laptops",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/9/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/9/1.jpg",
-   "https://cdn.dummyjson.com/product-images/9/2.png",
-   "https://cdn.dummyjson.com/product-images/9/3.png",
-   "https://cdn.dummyjson.com/product-images/9/4.jpg",
-   "https://cdn.dummyjson.com/product-images/9/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 10,
-   "title": "HP Pavilion 15-DK1056WM",
-   "description": "HP Pavilion 15-DK1056WM Gaming Laptop 10th Gen Core i5, 8GB, 256GB SSD, GTX 1650 4GB, Windows 10",
-   "price": 1099,
-   "discountPercentage": 6.18,
-   "rating": 4.43,
-   "stock": 89,
-   "brand": "HP Pavilion",
-   "category": "laptops",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/10/thumbnail.jpeg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/10/1.jpg",
-   "https://cdn.dummyjson.com/product-images/10/2.jpg",
-   "https://cdn.dummyjson.com/product-images/10/3.jpg",
-   "https://cdn.dummyjson.com/product-images/10/thumbnail.jpeg"
-   ]
-   },
-   {
-   "id": 11,
-   "title": "perfume Oil",
-   "description": "Mega Discount, Impression of Acqua Di Gio by GiorgioArmani concentrated attar perfume Oil",
-   "price": 13,
-   "discountPercentage": 8.4,
-   "rating": 4.26,
-   "stock": 65,
-   "brand": "Impression of Acqua Di Gio",
-   "category": "fragrances",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/11/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/11/1.jpg",
-   "https://cdn.dummyjson.com/product-images/11/2.jpg",
-   "https://cdn.dummyjson.com/product-images/11/3.jpg",
-   "https://cdn.dummyjson.com/product-images/11/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 12,
-   "title": "Brown Perfume",
-   "description": "Royal_Mirage Sport Brown Perfume for Men & Women - 120ml",
-   "price": 40,
-   "discountPercentage": 15.66,
-   "rating": 4,
-   "stock": 52,
-   "brand": "Royal_Mirage",
-   "category": "fragrances",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/12/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/12/1.jpg",
-   "https://cdn.dummyjson.com/product-images/12/2.jpg",
-   "https://cdn.dummyjson.com/product-images/12/3.png",
-   "https://cdn.dummyjson.com/product-images/12/4.jpg",
-   "https://cdn.dummyjson.com/product-images/12/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 13,
-   "title": "Fog Scent Xpressio Perfume",
-   "description": "Product details of Best Fog Scent Xpressio Perfume 100ml For Men cool long lasting perfumes for Men",
-   "price": 13,
-   "discountPercentage": 8.14,
-   "rating": 4.59,
-   "stock": 61,
-   "brand": "Fog Scent Xpressio",
-   "category": "fragrances",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/13/thumbnail.webp",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/13/1.jpg",
-   "https://cdn.dummyjson.com/product-images/13/2.png",
-   "https://cdn.dummyjson.com/product-images/13/3.jpg",
-   "https://cdn.dummyjson.com/product-images/13/4.jpg",
-   "https://cdn.dummyjson.com/product-images/13/thumbnail.webp"
-   ]
-   },
-   {
-   "id": 14,
-   "title": "Non-Alcoholic Concentrated Perfume Oil",
-   "description": "Original Al Munakh® by Mahal Al Musk | Our Impression of Climate | 6ml Non-Alcoholic Concentrated Perfume Oil",
-   "price": 120,
-   "discountPercentage": 15.6,
-   "rating": 4.21,
-   "stock": 114,
-   "brand": "Al Munakh",
-   "category": "fragrances",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/14/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/14/1.jpg",
-   "https://cdn.dummyjson.com/product-images/14/2.jpg",
-   "https://cdn.dummyjson.com/product-images/14/3.jpg",
-   "https://cdn.dummyjson.com/product-images/14/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 15,
-   "title": "Eau De Perfume Spray",
-   "description": "Genuine  Al-Rehab spray perfume from UAE/Saudi Arabia/Yemen High Quality",
-   "price": 30,
-   "discountPercentage": 10.99,
-   "rating": 4.7,
-   "stock": 105,
-   "brand": "Lord - Al-Rehab",
-   "category": "fragrances",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/15/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/15/1.jpg",
-   "https://cdn.dummyjson.com/product-images/15/2.jpg",
-   "https://cdn.dummyjson.com/product-images/15/3.jpg",
-   "https://cdn.dummyjson.com/product-images/15/4.jpg",
-   "https://cdn.dummyjson.com/product-images/15/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 16,
-   "title": "Hyaluronic Acid Serum",
-   "description": "L'OrÃ©al Paris introduces Hyaluron Expert Replumping Serum formulated with 1.5% Hyaluronic Acid",
-   "price": 19,
-   "discountPercentage": 13.31,
-   "rating": 4.83,
-   "stock": 110,
-   "brand": "L'Oreal Paris",
-   "category": "skincare",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/16/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/16/1.png",
-   "https://cdn.dummyjson.com/product-images/16/2.webp",
-   "https://cdn.dummyjson.com/product-images/16/3.jpg",
-   "https://cdn.dummyjson.com/product-images/16/4.jpg",
-   "https://cdn.dummyjson.com/product-images/16/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 17,
-   "title": "Tree Oil 30ml",
-   "description": "Tea tree oil contains a number of compounds, including terpinen-4-ol, that have been shown to kill certain bacteria,",
-   "price": 12,
-   "discountPercentage": 4.09,
-   "rating": 4.52,
-   "stock": 78,
-   "brand": "Hemani Tea",
-   "category": "skincare",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/17/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/17/1.jpg",
-   "https://cdn.dummyjson.com/product-images/17/2.jpg",
-   "https://cdn.dummyjson.com/product-images/17/3.jpg",
-   "https://cdn.dummyjson.com/product-images/17/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 18,
-   "title": "Oil Free Moisturizer 100ml",
-   "description": "Dermive Oil Free Moisturizer with SPF 20 is specifically formulated with ceramides, hyaluronic acid & sunscreen.",
-   "price": 40,
-   "discountPercentage": 13.1,
-   "rating": 4.56,
-   "stock": 88,
-   "brand": "Dermive",
-   "category": "skincare",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/18/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/18/1.jpg",
-   "https://cdn.dummyjson.com/product-images/18/2.jpg",
-   "https://cdn.dummyjson.com/product-images/18/3.jpg",
-   "https://cdn.dummyjson.com/product-images/18/4.jpg",
-   "https://cdn.dummyjson.com/product-images/18/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 19,
-   "title": "Skin Beauty Serum.",
-   "description": "Product name: rorec collagen hyaluronic acid white face serum riceNet weight: 15 m",
-   "price": 46,
-   "discountPercentage": 10.68,
-   "rating": 4.42,
-   "stock": 54,
-   "brand": "ROREC White Rice",
-   "category": "skincare",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/19/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/19/1.jpg",
-   "https://cdn.dummyjson.com/product-images/19/2.jpg",
-   "https://cdn.dummyjson.com/product-images/19/3.png",
-   "https://cdn.dummyjson.com/product-images/19/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 20,
-   "title": "Freckle Treatment Cream- 15gm",
-   "description": "Fair & Clear is Pakistan's only pure Freckle cream which helpsfade Freckles, Darkspots and pigments. Mercury level is 0%, so there are no side effects.",
-   "price": 70,
-   "discountPercentage": 16.99,
-   "rating": 4.06,
-   "stock": 140,
-   "brand": "Fair & Clear",
-   "category": "skincare",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/20/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/20/1.jpg",
-   "https://cdn.dummyjson.com/product-images/20/2.jpg",
-   "https://cdn.dummyjson.com/product-images/20/3.jpg",
-   "https://cdn.dummyjson.com/product-images/20/4.jpg",
-   "https://cdn.dummyjson.com/product-images/20/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 21,
-   "title": "- Daal Masoor 500 grams",
-   "description": "Fine quality Branded Product Keep in a cool and dry place",
-   "price": 20,
-   "discountPercentage": 4.81,
-   "rating": 4.44,
-   "stock": 133,
-   "brand": "Saaf & Khaas",
-   "category": "groceries",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/21/thumbnail.png",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/21/1.png",
-   "https://cdn.dummyjson.com/product-images/21/2.jpg",
-   "https://cdn.dummyjson.com/product-images/21/3.jpg"
-   ]
-   },
-   {
-   "id": 22,
-   "title": "Elbow Macaroni - 400 gm",
-   "description": "Product details of Bake Parlor Big Elbow Macaroni - 400 gm",
-   "price": 14,
-   "discountPercentage": 15.58,
-   "rating": 4.57,
-   "stock": 146,
-   "brand": "Bake Parlor Big",
-   "category": "groceries",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/22/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/22/1.jpg",
-   "https://cdn.dummyjson.com/product-images/22/2.jpg",
-   "https://cdn.dummyjson.com/product-images/22/3.jpg"
-   ]
-   },
-   {
-   "id": 23,
-   "title": "Orange Essence Food Flavou",
-   "description": "Specifications of Orange Essence Food Flavour For Cakes and Baking Food Item",
-   "price": 14,
-   "discountPercentage": 8.04,
-   "rating": 4.85,
-   "stock": 26,
-   "brand": "Baking Food Items",
-   "category": "groceries",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/23/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/23/1.jpg",
-   "https://cdn.dummyjson.com/product-images/23/2.jpg",
-   "https://cdn.dummyjson.com/product-images/23/3.jpg",
-   "https://cdn.dummyjson.com/product-images/23/4.jpg",
-   "https://cdn.dummyjson.com/product-images/23/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 24,
-   "title": "cereals muesli fruit nuts",
-   "description": "original fauji cereal muesli 250gm box pack original fauji cereals muesli fruit nuts flakes breakfast cereal break fast faujicereals cerels cerel foji fouji",
-   "price": 46,
-   "discountPercentage": 16.8,
-   "rating": 4.94,
-   "stock": 113,
-   "brand": "fauji",
-   "category": "groceries",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/24/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/24/1.jpg",
-   "https://cdn.dummyjson.com/product-images/24/2.jpg",
-   "https://cdn.dummyjson.com/product-images/24/3.jpg",
-   "https://cdn.dummyjson.com/product-images/24/4.jpg",
-   "https://cdn.dummyjson.com/product-images/24/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 25,
-   "title": "Gulab Powder 50 Gram",
-   "description": "Dry Rose Flower Powder Gulab Powder 50 Gram • Treats Wounds",
-   "price": 70,
-   "discountPercentage": 13.58,
-   "rating": 4.87,
-   "stock": 47,
-   "brand": "Dry Rose",
-   "category": "groceries",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/25/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/25/1.png",
-   "https://cdn.dummyjson.com/product-images/25/2.jpg",
-   "https://cdn.dummyjson.com/product-images/25/3.png",
-   "https://cdn.dummyjson.com/product-images/25/4.jpg",
-   "https://cdn.dummyjson.com/product-images/25/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 26,
-   "title": "Plant Hanger For Home",
-   "description": "Boho Decor Plant Hanger For Home Wall Decoration Macrame Wall Hanging Shelf",
-   "price": 41,
-   "discountPercentage": 17.86,
-   "rating": 4.08,
-   "stock": 131,
-   "brand": "Boho Decor",
-   "category": "home-decoration",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/26/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/26/1.jpg",
-   "https://cdn.dummyjson.com/product-images/26/2.jpg",
-   "https://cdn.dummyjson.com/product-images/26/3.jpg",
-   "https://cdn.dummyjson.com/product-images/26/4.jpg",
-   "https://cdn.dummyjson.com/product-images/26/5.jpg",
-   "https://cdn.dummyjson.com/product-images/26/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 27,
-   "title": "Flying Wooden Bird",
-   "description": "Package Include 6 Birds with Adhesive Tape Shape: 3D Shaped Wooden Birds Material: Wooden MDF, Laminated 3.5mm",
-   "price": 51,
-   "discountPercentage": 15.58,
-   "rating": 4.41,
-   "stock": 17,
-   "brand": "Flying Wooden",
-   "category": "home-decoration",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/27/thumbnail.webp",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/27/1.jpg",
-   "https://cdn.dummyjson.com/product-images/27/2.jpg",
-   "https://cdn.dummyjson.com/product-images/27/3.jpg",
-   "https://cdn.dummyjson.com/product-images/27/4.jpg",
-   "https://cdn.dummyjson.com/product-images/27/thumbnail.webp"
-   ]
-   },
-   {
-   "id": 28,
-   "title": "3D Embellishment Art Lamp",
-   "description": "3D led lamp sticker Wall sticker 3d wall art light on/off button  cell operated (included)",
-   "price": 20,
-   "discountPercentage": 16.49,
-   "rating": 4.82,
-   "stock": 54,
-   "brand": "LED Lights",
-   "category": "home-decoration",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/28/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/28/1.jpg",
-   "https://cdn.dummyjson.com/product-images/28/2.jpg",
-   "https://cdn.dummyjson.com/product-images/28/3.png",
-   "https://cdn.dummyjson.com/product-images/28/4.jpg",
-   "https://cdn.dummyjson.com/product-images/28/thumbnail.jpg"
-   ]
-   },
-   {
-   "id": 29,
-   "title": "Handcraft Chinese style",
-   "description": "Handcraft Chinese style art luxury palace hotel villa mansion home decor ceramic vase with brass fruit plate",
-   "price": 60,
-   "discountPercentage": 15.34,
-   "rating": 4.44,
-   "stock": 7,
-   "brand": "luxury palace",
-   "category": "home-decoration",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/29/thumbnail.webp",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/29/1.jpg",
-   "https://cdn.dummyjson.com/product-images/29/2.jpg",
-   "https://cdn.dummyjson.com/product-images/29/3.webp",
-   "https://cdn.dummyjson.com/product-images/29/4.webp",
-   "https://cdn.dummyjson.com/product-images/29/thumbnail.webp"
-   ]
-   },
-   {
-   "id": 30,
-   "title": "Key Holder",
-   "description": "Attractive DesignMetallic materialFour key hooksReliable & DurablePremium Quality",
-   "price": 30,
-   "discountPercentage": 2.92,
-   "rating": 4.92,
-   "stock": 54,
-   "brand": "Golden",
-   "category": "home-decoration",
-   "thumbnail": "https://cdn.dummyjson.com/product-images/30/thumbnail.jpg",
-   "images": [
-   "https://cdn.dummyjson.com/product-images/30/1.jpg",
-   "https://cdn.dummyjson.com/product-images/30/2.jpg",
-   "https://cdn.dummyjson.com/product-images/30/3.jpg",
-   "https://cdn.dummyjson.com/product-images/30/thumbnail.jpg"
-   ]
-   }
-   ],
-   "total": 100,
-   "skip": 0,
-   "limit": 30
-   }
+  "products": [
+    {
+      "id": 1,
+      "title": "Essence Mascara Lash Princess",
+      "description": "The Essence Mascara Lash Princess is a popular mascara known for its volumizing and lengthening effects. Achieve dramatic lashes with this long-lasting and cruelty-free formula.",
+      "category": "beauty",
+      "price": 9.99,
+      "discountPercentage": 10.48,
+      "rating": 2.56,
+      "stock": 99,
+      "tags": ["beauty", "mascara"],
+      "brand": "Essence",
+      "sku": "BEA-ESS-ESS-001",
+      "weight": 4,
+      "dimensions": { "width": 15.14, "height": 13.08, "depth": 22.99 },
+      "warrantyInformation": "1 week warranty",
+      "shippingInformation": "Ships in 3-5 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 3,
+          "comment": "Would not recommend!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Eleanor Collins",
+          "reviewerEmail": "eleanor.collins@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Very satisfied!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Lucas Gordon",
+          "reviewerEmail": "lucas.gordon@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Eleanor Collins",
+          "reviewerEmail": "eleanor.collins@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 48,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "5784719087687",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/beauty/essence-mascara-lash-princess/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/beauty/essence-mascara-lash-princess/thumbnail.webp"
+    },
+    {
+      "id": 2,
+      "title": "Eyeshadow Palette with Mirror",
+      "description": "The Eyeshadow Palette with Mirror offers a versatile range of eyeshadow shades for creating stunning eye looks. With a built-in mirror, it's convenient for on-the-go makeup application.",
+      "category": "beauty",
+      "price": 19.99,
+      "discountPercentage": 18.19,
+      "rating": 2.86,
+      "stock": 34,
+      "tags": ["beauty", "eyeshadow"],
+      "brand": "Glamour Beauty",
+      "sku": "BEA-GLA-EYE-002",
+      "weight": 9,
+      "dimensions": { "width": 9.26, "height": 22.47, "depth": 27.67 },
+      "warrantyInformation": "1 year warranty",
+      "shippingInformation": "Ships in 2 weeks",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Savannah Gomez",
+          "reviewerEmail": "savannah.gomez@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Awesome product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Christian Perez",
+          "reviewerEmail": "christian.perez@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nicholas Bailey",
+          "reviewerEmail": "nicholas.bailey@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 20,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "9170275171413",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/beauty/eyeshadow-palette-with-mirror/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/beauty/eyeshadow-palette-with-mirror/thumbnail.webp"
+    },
+    {
+      "id": 3,
+      "title": "Powder Canister",
+      "description": "The Powder Canister is a finely milled setting powder designed to set makeup and control shine. With a lightweight and translucent formula, it provides a smooth and matte finish.",
+      "category": "beauty",
+      "price": 14.99,
+      "discountPercentage": 9.84,
+      "rating": 4.64,
+      "stock": 89,
+      "tags": ["beauty", "face powder"],
+      "brand": "Velvet Touch",
+      "sku": "BEA-VEL-POW-003",
+      "weight": 8,
+      "dimensions": { "width": 29.27, "height": 27.93, "depth": 20.59 },
+      "warrantyInformation": "3 months warranty",
+      "shippingInformation": "Ships in 1-2 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Would buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Alexander Jones",
+          "reviewerEmail": "alexander.jones@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Elijah Cruz",
+          "reviewerEmail": "elijah.cruz@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Very dissatisfied!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Avery Perez",
+          "reviewerEmail": "avery.perez@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 22,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "8418883906837",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/beauty/powder-canister/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/beauty/powder-canister/thumbnail.webp"
+    },
+    {
+      "id": 4,
+      "title": "Red Lipstick",
+      "description": "The Red Lipstick is a classic and bold choice for adding a pop of color to your lips. With a creamy and pigmented formula, it provides a vibrant and long-lasting finish.",
+      "category": "beauty",
+      "price": 12.99,
+      "discountPercentage": 12.16,
+      "rating": 4.36,
+      "stock": 91,
+      "tags": ["beauty", "lipstick"],
+      "brand": "Chic Cosmetics",
+      "sku": "BEA-CHI-LIP-004",
+      "weight": 1,
+      "dimensions": { "width": 18.11, "height": 28.38, "depth": 22.17 },
+      "warrantyInformation": "3 year warranty",
+      "shippingInformation": "Ships in 1 week",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Liam Garcia",
+          "reviewerEmail": "liam.garcia@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Ruby Andrews",
+          "reviewerEmail": "ruby.andrews@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Would buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Clara Berry",
+          "reviewerEmail": "clara.berry@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 40,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "9467746727219",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/beauty/red-lipstick/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/beauty/red-lipstick/thumbnail.webp"
+    },
+    {
+      "id": 5,
+      "title": "Red Nail Polish",
+      "description": "The Red Nail Polish offers a rich and glossy red hue for vibrant and polished nails. With a quick-drying formula, it provides a salon-quality finish at home.",
+      "category": "beauty",
+      "price": 8.99,
+      "discountPercentage": 11.44,
+      "rating": 4.32,
+      "stock": 79,
+      "tags": ["beauty", "nail polish"],
+      "brand": "Nail Couture",
+      "sku": "BEA-NAI-NAI-005",
+      "weight": 8,
+      "dimensions": { "width": 21.63, "height": 16.48, "depth": 29.84 },
+      "warrantyInformation": "1 month warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 2,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Benjamin Wilson",
+          "reviewerEmail": "benjamin.wilson@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Liam Smith",
+          "reviewerEmail": "liam.smith@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Very unhappy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Clara Berry",
+          "reviewerEmail": "clara.berry@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 22,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "4063010628104",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/beauty/red-nail-polish/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/beauty/red-nail-polish/thumbnail.webp"
+    },
+    {
+      "id": 6,
+      "title": "Calvin Klein CK One",
+      "description": "CK One by Calvin Klein is a classic unisex fragrance, known for its fresh and clean scent. It's a versatile fragrance suitable for everyday wear.",
+      "category": "fragrances",
+      "price": 49.99,
+      "discountPercentage": 1.89,
+      "rating": 4.37,
+      "stock": 29,
+      "tags": ["fragrances", "perfumes"],
+      "brand": "Calvin Klein",
+      "sku": "FRA-CAL-CAL-006",
+      "weight": 7,
+      "dimensions": { "width": 29.36, "height": 27.76, "depth": 20.72 },
+      "warrantyInformation": "1 week warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 2,
+          "comment": "Very disappointed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Layla Young",
+          "reviewerEmail": "layla.young@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Fast shipping!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Daniel Cook",
+          "reviewerEmail": "daniel.cook@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Not as described!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Jacob Cooper",
+          "reviewerEmail": "jacob.cooper@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "90 days return policy",
+      "minimumOrderQuantity": 9,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "2451534060749",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/fragrances/calvin-klein-ck-one/1.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/calvin-klein-ck-one/2.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/calvin-klein-ck-one/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/fragrances/calvin-klein-ck-one/thumbnail.webp"
+    },
+    {
+      "id": 7,
+      "title": "Chanel Coco Noir Eau De",
+      "description": "Coco Noir by Chanel is an elegant and mysterious fragrance, featuring notes of grapefruit, rose, and sandalwood. Perfect for evening occasions.",
+      "category": "fragrances",
+      "price": 129.99,
+      "discountPercentage": 16.51,
+      "rating": 4.26,
+      "stock": 58,
+      "tags": ["fragrances", "perfumes"],
+      "brand": "Chanel",
+      "sku": "FRA-CHA-CHA-007",
+      "weight": 7,
+      "dimensions": { "width": 24.5, "height": 25.7, "depth": 25.98 },
+      "warrantyInformation": "3 year warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Ruby Andrews",
+          "reviewerEmail": "ruby.andrews@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Awesome product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Leah Henderson",
+          "reviewerEmail": "leah.henderson@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Very happy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Xavier Wright",
+          "reviewerEmail": "xavier.wright@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 1,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "4091737746820",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/fragrances/chanel-coco-noir-eau-de/1.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/chanel-coco-noir-eau-de/2.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/chanel-coco-noir-eau-de/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/fragrances/chanel-coco-noir-eau-de/thumbnail.webp"
+    },
+    {
+      "id": 8,
+      "title": "Dior J'adore",
+      "description": "J'adore by Dior is a luxurious and floral fragrance, known for its blend of ylang-ylang, rose, and jasmine. It embodies femininity and sophistication.",
+      "category": "fragrances",
+      "price": 89.99,
+      "discountPercentage": 14.72,
+      "rating": 3.8,
+      "stock": 98,
+      "tags": ["fragrances", "perfumes"],
+      "brand": "Dior",
+      "sku": "FRA-DIO-DIO-008",
+      "weight": 4,
+      "dimensions": { "width": 27.67, "height": 28.28, "depth": 11.83 },
+      "warrantyInformation": "1 week warranty",
+      "shippingInformation": "Ships in 2 weeks",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Great value for money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nicholas Bailey",
+          "reviewerEmail": "nicholas.bailey@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Great value for money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Penelope Harper",
+          "reviewerEmail": "penelope.harper@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Emma Miller",
+          "reviewerEmail": "emma.miller@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 10,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "1445086097250",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/fragrances/dior-j'adore/1.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/dior-j'adore/2.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/dior-j'adore/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/fragrances/dior-j'adore/thumbnail.webp"
+    },
+    {
+      "id": 9,
+      "title": "Dolce Shine Eau de",
+      "description": "Dolce Shine by Dolce & Gabbana is a vibrant and fruity fragrance, featuring notes of mango, jasmine, and blonde woods. It's a joyful and youthful scent.",
+      "category": "fragrances",
+      "price": 69.99,
+      "discountPercentage": 0.62,
+      "rating": 3.96,
+      "stock": 4,
+      "tags": ["fragrances", "perfumes"],
+      "brand": "Dolce & Gabbana",
+      "sku": "FRA-DOL-DOL-009",
+      "weight": 6,
+      "dimensions": { "width": 27.28, "height": 29.88, "depth": 18.3 },
+      "warrantyInformation": "3 year warranty",
+      "shippingInformation": "Ships in 1 month",
+      "availabilityStatus": "Low Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Would buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Mateo Bennett",
+          "reviewerEmail": "mateo.bennett@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Highly recommended!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nolan Gonzalez",
+          "reviewerEmail": "nolan.gonzalez@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Very happy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Aurora Lawson",
+          "reviewerEmail": "aurora.lawson@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 2,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "3023868210708",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/fragrances/dolce-shine-eau-de/1.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/dolce-shine-eau-de/2.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/dolce-shine-eau-de/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/fragrances/dolce-shine-eau-de/thumbnail.webp"
+    },
+    {
+      "id": 10,
+      "title": "Gucci Bloom Eau de",
+      "description": "Gucci Bloom by Gucci is a floral and captivating fragrance, with notes of tuberose, jasmine, and Rangoon creeper. It's a modern and romantic scent.",
+      "category": "fragrances",
+      "price": 79.99,
+      "discountPercentage": 14.39,
+      "rating": 2.74,
+      "stock": 91,
+      "tags": ["fragrances", "perfumes"],
+      "brand": "Gucci",
+      "sku": "FRA-GUC-GUC-010",
+      "weight": 7,
+      "dimensions": { "width": 20.92, "height": 21.68, "depth": 11.2 },
+      "warrantyInformation": "6 months warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 1,
+          "comment": "Very dissatisfied!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Cameron Perez",
+          "reviewerEmail": "cameron.perez@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Very happy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Daniel Cook",
+          "reviewerEmail": "daniel.cook@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Addison Wright",
+          "reviewerEmail": "addison.wright@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 2,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "3170832177880",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/fragrances/gucci-bloom-eau-de/1.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/gucci-bloom-eau-de/2.webp",
+        "https://cdn.dummyjson.com/product-images/fragrances/gucci-bloom-eau-de/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/fragrances/gucci-bloom-eau-de/thumbnail.webp"
+    },
+    {
+      "id": 11,
+      "title": "Annibale Colombo Bed",
+      "description": "The Annibale Colombo Bed is a luxurious and elegant bed frame, crafted with high-quality materials for a comfortable and stylish bedroom.",
+      "category": "furniture",
+      "price": 1899.99,
+      "discountPercentage": 8.57,
+      "rating": 4.77,
+      "stock": 88,
+      "tags": ["furniture", "beds"],
+      "brand": "Annibale Colombo",
+      "sku": "FUR-ANN-ANN-011",
+      "weight": 10,
+      "dimensions": { "width": 28.16, "height": 25.36, "depth": 17.28 },
+      "warrantyInformation": "1 year warranty",
+      "shippingInformation": "Ships in 1 month",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 2,
+          "comment": "Would not recommend!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Christopher West",
+          "reviewerEmail": "christopher.west@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Vivian Carter",
+          "reviewerEmail": "vivian.carter@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Mason Wright",
+          "reviewerEmail": "mason.wright@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 1,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "3610757456581",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-bed/1.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-bed/2.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-bed/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-bed/thumbnail.webp"
+    },
+    {
+      "id": 12,
+      "title": "Annibale Colombo Sofa",
+      "description": "The Annibale Colombo Sofa is a sophisticated and comfortable seating option, featuring exquisite design and premium upholstery for your living room.",
+      "category": "furniture",
+      "price": 2499.99,
+      "discountPercentage": 14.4,
+      "rating": 3.92,
+      "stock": 60,
+      "tags": ["furniture", "sofas"],
+      "brand": "Annibale Colombo",
+      "sku": "FUR-ANN-ANN-012",
+      "weight": 6,
+      "dimensions": { "width": 12.75, "height": 20.55, "depth": 19.06 },
+      "warrantyInformation": "Lifetime warranty",
+      "shippingInformation": "Ships in 1 week",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 3,
+          "comment": "Very unhappy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Christian Perez",
+          "reviewerEmail": "christian.perez@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Fast shipping!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Lillian Bishop",
+          "reviewerEmail": "lillian.bishop@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Lillian Simmons",
+          "reviewerEmail": "lillian.simmons@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 1,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "1777662847736",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-sofa/1.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-sofa/2.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-sofa/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/furniture/annibale-colombo-sofa/thumbnail.webp"
+    },
+    {
+      "id": 13,
+      "title": "Bedside Table African Cherry",
+      "description": "The Bedside Table in African Cherry is a stylish and functional addition to your bedroom, providing convenient storage space and a touch of elegance.",
+      "category": "furniture",
+      "price": 299.99,
+      "discountPercentage": 19.09,
+      "rating": 2.87,
+      "stock": 64,
+      "tags": ["furniture", "bedside tables"],
+      "brand": "Furniture Co.",
+      "sku": "FUR-FUR-BED-013",
+      "weight": 2,
+      "dimensions": { "width": 13.47, "height": 24.99, "depth": 27.35 },
+      "warrantyInformation": "5 year warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Aaliyah Hanson",
+          "reviewerEmail": "aaliyah.hanson@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Liam Smith",
+          "reviewerEmail": "liam.smith@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Highly recommended!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Avery Barnes",
+          "reviewerEmail": "avery.barnes@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 3,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "6441287925979",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/furniture/bedside-table-african-cherry/1.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/bedside-table-african-cherry/2.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/bedside-table-african-cherry/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/furniture/bedside-table-african-cherry/thumbnail.webp"
+    },
+    {
+      "id": 14,
+      "title": "Knoll Saarinen Executive Conference Chair",
+      "description": "The Knoll Saarinen Executive Conference Chair is a modern and ergonomic chair, perfect for your office or conference room with its timeless design.",
+      "category": "furniture",
+      "price": 499.99,
+      "discountPercentage": 2.01,
+      "rating": 4.88,
+      "stock": 26,
+      "tags": ["furniture", "office chairs"],
+      "brand": "Knoll",
+      "sku": "FUR-KNO-KNO-014",
+      "weight": 10,
+      "dimensions": { "width": 13.81, "height": 7.5, "depth": 5.62 },
+      "warrantyInformation": "2 year warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 2,
+          "comment": "Waste of money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Ella Cook",
+          "reviewerEmail": "ella.cook@x.dummyjson.com"
+        },
+        {
+          "rating": 2,
+          "comment": "Very dissatisfied!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Clara Berry",
+          "reviewerEmail": "clara.berry@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Would buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Elena Long",
+          "reviewerEmail": "elena.long@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "60 days return policy",
+      "minimumOrderQuantity": 5,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "8919386859966",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/furniture/knoll-saarinen-executive-conference-chair/1.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/knoll-saarinen-executive-conference-chair/2.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/knoll-saarinen-executive-conference-chair/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/furniture/knoll-saarinen-executive-conference-chair/thumbnail.webp"
+    },
+    {
+      "id": 15,
+      "title": "Wooden Bathroom Sink With Mirror",
+      "description": "The Wooden Bathroom Sink with Mirror is a unique and stylish addition to your bathroom, featuring a wooden sink countertop and a matching mirror.",
+      "category": "furniture",
+      "price": 799.99,
+      "discountPercentage": 8.8,
+      "rating": 3.59,
+      "stock": 7,
+      "tags": ["furniture", "bathroom"],
+      "brand": "Bath Trends",
+      "sku": "FUR-BAT-WOO-015",
+      "weight": 10,
+      "dimensions": { "width": 7.98, "height": 8.88, "depth": 28.46 },
+      "warrantyInformation": "3 year warranty",
+      "shippingInformation": "Ships in 3-5 business days",
+      "availabilityStatus": "Low Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Fast shipping!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Logan Torres",
+          "reviewerEmail": "logan.torres@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Very pleased!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Aria Parker",
+          "reviewerEmail": "aria.parker@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Dylan Wells",
+          "reviewerEmail": "dylan.wells@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "60 days return policy",
+      "minimumOrderQuantity": 2,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "1958104402873",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/furniture/wooden-bathroom-sink-with-mirror/1.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/wooden-bathroom-sink-with-mirror/2.webp",
+        "https://cdn.dummyjson.com/product-images/furniture/wooden-bathroom-sink-with-mirror/3.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/furniture/wooden-bathroom-sink-with-mirror/thumbnail.webp"
+    },
+    {
+      "id": 16,
+      "title": "Apple",
+      "description": "Fresh and crisp apples, perfect for snacking or incorporating into various recipes.",
+      "category": "groceries",
+      "price": 1.99,
+      "discountPercentage": 12.62,
+      "rating": 4.19,
+      "stock": 8,
+      "tags": ["fruits"],
+      "sku": "GRO-BRD-APP-016",
+      "weight": 9,
+      "dimensions": { "width": 13.66, "height": 11.01, "depth": 9.73 },
+      "warrantyInformation": "3 year warranty",
+      "shippingInformation": "Ships in 2 weeks",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Very satisfied!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Sophia Brown",
+          "reviewerEmail": "sophia.brown@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Very dissatisfied!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Scarlett Bowman",
+          "reviewerEmail": "scarlett.bowman@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Very unhappy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "William Gonzalez",
+          "reviewerEmail": "william.gonzalez@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "90 days return policy",
+      "minimumOrderQuantity": 7,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "7962803553314",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/apple/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/apple/thumbnail.webp"
+    },
+    {
+      "id": 17,
+      "title": "Beef Steak",
+      "description": "High-quality beef steak, great for grilling or cooking to your preferred level of doneness.",
+      "category": "groceries",
+      "price": 12.99,
+      "discountPercentage": 9.61,
+      "rating": 4.47,
+      "stock": 86,
+      "tags": ["meat"],
+      "sku": "GRO-BRD-BEE-017",
+      "weight": 10,
+      "dimensions": { "width": 18.9, "height": 5.77, "depth": 18.57 },
+      "warrantyInformation": "3 year warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 3,
+          "comment": "Would not recommend!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Eleanor Tyler",
+          "reviewerEmail": "eleanor.tyler@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Fast shipping!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Alexander Jones",
+          "reviewerEmail": "alexander.jones@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Great value for money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Natalie Harris",
+          "reviewerEmail": "natalie.harris@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "60 days return policy",
+      "minimumOrderQuantity": 43,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "5640063409695",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/beef-steak/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/beef-steak/thumbnail.webp"
+    },
+    {
+      "id": 18,
+      "title": "Cat Food",
+      "description": "Nutritious cat food formulated to meet the dietary needs of your feline friend.",
+      "category": "groceries",
+      "price": 8.99,
+      "discountPercentage": 9.58,
+      "rating": 3.13,
+      "stock": 46,
+      "tags": ["pet supplies", "cat food"],
+      "sku": "GRO-BRD-FOO-018",
+      "weight": 10,
+      "dimensions": { "width": 18.08, "height": 9.26, "depth": 21.86 },
+      "warrantyInformation": "1 year warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 3,
+          "comment": "Would not recommend!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Noah Lewis",
+          "reviewerEmail": "noah.lewis@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Very unhappy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Ruby Andrews",
+          "reviewerEmail": "ruby.andrews@x.dummyjson.com"
+        },
+        {
+          "rating": 2,
+          "comment": "Very disappointed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Ethan Thompson",
+          "reviewerEmail": "ethan.thompson@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 18,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "1483991328610",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/cat-food/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/cat-food/thumbnail.webp"
+    },
+    {
+      "id": 19,
+      "title": "Chicken Meat",
+      "description": "Fresh and tender chicken meat, suitable for various culinary preparations.",
+      "category": "groceries",
+      "price": 9.99,
+      "discountPercentage": 13.7,
+      "rating": 3.19,
+      "stock": 97,
+      "tags": ["meat"],
+      "sku": "GRO-BRD-CHI-019",
+      "weight": 1,
+      "dimensions": { "width": 11.03, "height": 22.11, "depth": 16.01 },
+      "warrantyInformation": "1 year warranty",
+      "shippingInformation": "Ships in 1 month",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Mateo Bennett",
+          "reviewerEmail": "mateo.bennett@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Highly recommended!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Jackson Evans",
+          "reviewerEmail": "jackson.evans@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Not worth the price!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Sadie Morales",
+          "reviewerEmail": "sadie.morales@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 22,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "8829514594521",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/chicken-meat/1.webp",
+        "https://cdn.dummyjson.com/product-images/groceries/chicken-meat/2.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/chicken-meat/thumbnail.webp"
+    },
+    {
+      "id": 20,
+      "title": "Cooking Oil",
+      "description": "Versatile cooking oil suitable for frying, sautéing, and various culinary applications.",
+      "category": "groceries",
+      "price": 4.99,
+      "discountPercentage": 9.33,
+      "rating": 4.8,
+      "stock": 10,
+      "tags": ["cooking essentials"],
+      "sku": "GRO-BRD-COO-020",
+      "weight": 5,
+      "dimensions": { "width": 19.95, "height": 27.54, "depth": 24.86 },
+      "warrantyInformation": "Lifetime warranty",
+      "shippingInformation": "Ships in 1-2 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Very happy with my purchase!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Victoria McDonald",
+          "reviewerEmail": "victoria.mcdonald@x.dummyjson.com"
+        },
+        {
+          "rating": 2,
+          "comment": "Would not recommend!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Hazel Evans",
+          "reviewerEmail": "hazel.evans@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Would buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Zoe Bennett",
+          "reviewerEmail": "zoe.bennett@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "30 days return policy",
+      "minimumOrderQuantity": 46,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "4874727824518",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/cooking-oil/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/cooking-oil/thumbnail.webp"
+    },
+    {
+      "id": 21,
+      "title": "Cucumber",
+      "description": "Crisp and hydrating cucumbers, ideal for salads, snacks, or as a refreshing side.",
+      "category": "groceries",
+      "price": 1.49,
+      "discountPercentage": 0.16,
+      "rating": 4.07,
+      "stock": 84,
+      "tags": ["vegetables"],
+      "sku": "GRO-BRD-CUC-021",
+      "weight": 4,
+      "dimensions": { "width": 12.8, "height": 28.38, "depth": 21.34 },
+      "warrantyInformation": "2 year warranty",
+      "shippingInformation": "Ships in 1-2 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Lincoln Kelly",
+          "reviewerEmail": "lincoln.kelly@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Great value for money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Savannah Gomez",
+          "reviewerEmail": "savannah.gomez@x.dummyjson.com"
+        },
+        {
+          "rating": 2,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "James Davis",
+          "reviewerEmail": "james.davis@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 2,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "5300066378225",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/cucumber/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/cucumber/thumbnail.webp"
+    },
+    {
+      "id": 22,
+      "title": "Dog Food",
+      "description": "Specially formulated dog food designed to provide essential nutrients for your canine companion.",
+      "category": "groceries",
+      "price": 10.99,
+      "discountPercentage": 10.27,
+      "rating": 4.55,
+      "stock": 71,
+      "tags": ["pet supplies", "dog food"],
+      "sku": "GRO-BRD-FOO-022",
+      "weight": 10,
+      "dimensions": { "width": 16.93, "height": 27.15, "depth": 9.29 },
+      "warrantyInformation": "No warranty",
+      "shippingInformation": "Ships in 1-2 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nicholas Edwards",
+          "reviewerEmail": "nicholas.edwards@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Awesome product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Zachary Lee",
+          "reviewerEmail": "zachary.lee@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nova Cooper",
+          "reviewerEmail": "nova.cooper@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "60 days return policy",
+      "minimumOrderQuantity": 43,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "5906686116469",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/dog-food/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/dog-food/thumbnail.webp"
+    },
+    {
+      "id": 23,
+      "title": "Eggs",
+      "description": "Fresh eggs, a versatile ingredient for baking, cooking, or breakfast.",
+      "category": "groceries",
+      "price": 2.99,
+      "discountPercentage": 11.05,
+      "rating": 2.53,
+      "stock": 9,
+      "tags": ["dairy"],
+      "sku": "GRO-BRD-EGG-023",
+      "weight": 2,
+      "dimensions": { "width": 11.42, "height": 7.44, "depth": 16.95 },
+      "warrantyInformation": "1 week warranty",
+      "shippingInformation": "Ships in 1 week",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 3,
+          "comment": "Disappointing product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Penelope King",
+          "reviewerEmail": "penelope.king@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Poor quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Eleanor Tyler",
+          "reviewerEmail": "eleanor.tyler@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Very pleased!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Benjamin Foster",
+          "reviewerEmail": "benjamin.foster@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 32,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "3478638588469",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/eggs/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/eggs/thumbnail.webp"
+    },
+    {
+      "id": 24,
+      "title": "Fish Steak",
+      "description": "Quality fish steak, suitable for grilling, baking, or pan-searing.",
+      "category": "groceries",
+      "price": 14.99,
+      "discountPercentage": 4.23,
+      "rating": 3.78,
+      "stock": 74,
+      "tags": ["seafood"],
+      "sku": "GRO-BRD-FIS-024",
+      "weight": 6,
+      "dimensions": { "width": 14.95, "height": 26.31, "depth": 11.27 },
+      "warrantyInformation": "1 month warranty",
+      "shippingInformation": "Ships in 3-5 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 2,
+          "comment": "Would not buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Caleb Perkins",
+          "reviewerEmail": "caleb.perkins@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Isabella Jackson",
+          "reviewerEmail": "isabella.jackson@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Great value for money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nathan Dixon",
+          "reviewerEmail": "nathan.dixon@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "60 days return policy",
+      "minimumOrderQuantity": 50,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "9595036192098",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/fish-steak/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/fish-steak/thumbnail.webp"
+    },
+    {
+      "id": 25,
+      "title": "Green Bell Pepper",
+      "description": "Fresh and vibrant green bell pepper, perfect for adding color and flavor to your dishes.",
+      "category": "groceries",
+      "price": 1.29,
+      "discountPercentage": 0.16,
+      "rating": 3.25,
+      "stock": 33,
+      "tags": ["vegetables"],
+      "sku": "GRO-BRD-GRE-025",
+      "weight": 2,
+      "dimensions": { "width": 15.33, "height": 26.65, "depth": 14.44 },
+      "warrantyInformation": "1 month warranty",
+      "shippingInformation": "Ships in 1 week",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Highly recommended!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Avery Carter",
+          "reviewerEmail": "avery.carter@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Would not recommend!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Henry Hill",
+          "reviewerEmail": "henry.hill@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Addison Wright",
+          "reviewerEmail": "addison.wright@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "30 days return policy",
+      "minimumOrderQuantity": 12,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "2365227493323",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/green-bell-pepper/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/green-bell-pepper/thumbnail.webp"
+    },
+    {
+      "id": 26,
+      "title": "Green Chili Pepper",
+      "description": "Spicy green chili pepper, ideal for adding heat to your favorite recipes.",
+      "category": "groceries",
+      "price": 0.99,
+      "discountPercentage": 1,
+      "rating": 3.66,
+      "stock": 3,
+      "tags": ["vegetables"],
+      "sku": "GRO-BRD-GRE-026",
+      "weight": 7,
+      "dimensions": { "width": 15.38, "height": 18.12, "depth": 19.92 },
+      "warrantyInformation": "2 year warranty",
+      "shippingInformation": "Ships in 1 week",
+      "availabilityStatus": "Low Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Great product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Luna Russell",
+          "reviewerEmail": "luna.russell@x.dummyjson.com"
+        },
+        {
+          "rating": 1,
+          "comment": "Waste of money!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Noah Lewis",
+          "reviewerEmail": "noah.lewis@x.dummyjson.com"
+        },
+        {
+          "rating": 3,
+          "comment": "Very disappointed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Clara Berry",
+          "reviewerEmail": "clara.berry@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "30 days return policy",
+      "minimumOrderQuantity": 39,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "9335000538563",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/green-chili-pepper/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/green-chili-pepper/thumbnail.webp"
+    },
+    {
+      "id": 27,
+      "title": "Honey Jar",
+      "description": "Pure and natural honey in a convenient jar, perfect for sweetening beverages or drizzling over food.",
+      "category": "groceries",
+      "price": 6.99,
+      "discountPercentage": 14.4,
+      "rating": 3.97,
+      "stock": 34,
+      "tags": ["condiments"],
+      "sku": "GRO-BRD-HON-027",
+      "weight": 2,
+      "dimensions": { "width": 9.28, "height": 21.72, "depth": 17.74 },
+      "warrantyInformation": "1 month warranty",
+      "shippingInformation": "Ships in 1-2 business days",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 1,
+          "comment": "Very disappointed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Autumn Gomez",
+          "reviewerEmail": "autumn.gomez@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Benjamin Wilson",
+          "reviewerEmail": "benjamin.wilson@x.dummyjson.com"
+        },
+        {
+          "rating": 2,
+          "comment": "Very disappointed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nicholas Edwards",
+          "reviewerEmail": "nicholas.edwards@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "90 days return policy",
+      "minimumOrderQuantity": 47,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "6354306346329",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/honey-jar/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/honey-jar/thumbnail.webp"
+    },
+    {
+      "id": 28,
+      "title": "Ice Cream",
+      "description": "Creamy and delicious ice cream, available in various flavors for a delightful treat.",
+      "category": "groceries",
+      "price": 5.49,
+      "discountPercentage": 8.69,
+      "rating": 3.39,
+      "stock": 27,
+      "tags": ["desserts"],
+      "sku": "GRO-BRD-CRE-028",
+      "weight": 1,
+      "dimensions": { "width": 14.83, "height": 15.07, "depth": 24.2 },
+      "warrantyInformation": "1 month warranty",
+      "shippingInformation": "Ships in 2 weeks",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Very pleased!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Elijah Cruz",
+          "reviewerEmail": "elijah.cruz@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Jace Smith",
+          "reviewerEmail": "jace.smith@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Highly impressed!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Sadie Morales",
+          "reviewerEmail": "sadie.morales@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 42,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "0788954559076",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/ice-cream/1.webp",
+        "https://cdn.dummyjson.com/product-images/groceries/ice-cream/2.webp",
+        "https://cdn.dummyjson.com/product-images/groceries/ice-cream/3.webp",
+        "https://cdn.dummyjson.com/product-images/groceries/ice-cream/4.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/ice-cream/thumbnail.webp"
+    },
+    {
+      "id": 29,
+      "title": "Juice",
+      "description": "Refreshing fruit juice, packed with vitamins and great for staying hydrated.",
+      "category": "groceries",
+      "price": 3.99,
+      "discountPercentage": 12.06,
+      "rating": 3.94,
+      "stock": 50,
+      "tags": ["beverages"],
+      "sku": "GRO-BRD-JUI-029",
+      "weight": 1,
+      "dimensions": { "width": 18.56, "height": 21.46, "depth": 28.02 },
+      "warrantyInformation": "6 months warranty",
+      "shippingInformation": "Ships in 1 week",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 5,
+          "comment": "Excellent quality!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nolan Gonzalez",
+          "reviewerEmail": "nolan.gonzalez@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Would buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Bella Grant",
+          "reviewerEmail": "bella.grant@x.dummyjson.com"
+        },
+        {
+          "rating": 5,
+          "comment": "Awesome product!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Aria Flores",
+          "reviewerEmail": "aria.flores@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "No return policy",
+      "minimumOrderQuantity": 25,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "6936112580956",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/juice/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/juice/thumbnail.webp"
+    },
+    {
+      "id": 30,
+      "title": "Kiwi",
+      "description": "Nutrient-rich kiwi, perfect for snacking or adding a tropical twist to your dishes.",
+      "category": "groceries",
+      "price": 2.49,
+      "discountPercentage": 15.22,
+      "rating": 4.93,
+      "stock": 99,
+      "tags": ["fruits"],
+      "sku": "GRO-BRD-KIW-030",
+      "weight": 5,
+      "dimensions": { "width": 19.4, "height": 18.67, "depth": 17.13 },
+      "warrantyInformation": "6 months warranty",
+      "shippingInformation": "Ships overnight",
+      "availabilityStatus": "In Stock",
+      "reviews": [
+        {
+          "rating": 4,
+          "comment": "Highly recommended!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Emily Brown",
+          "reviewerEmail": "emily.brown@x.dummyjson.com"
+        },
+        {
+          "rating": 2,
+          "comment": "Would not buy again!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Jackson Morales",
+          "reviewerEmail": "jackson.morales@x.dummyjson.com"
+        },
+        {
+          "rating": 4,
+          "comment": "Fast shipping!",
+          "date": "2025-04-30T09:41:02.053Z",
+          "reviewerName": "Nora Russell",
+          "reviewerEmail": "nora.russell@x.dummyjson.com"
+        }
+      ],
+      "returnPolicy": "7 days return policy",
+      "minimumOrderQuantity": 30,
+      "meta": {
+        "createdAt": "2025-04-30T09:41:02.053Z",
+        "updatedAt": "2025-04-30T09:41:02.053Z",
+        "barcode": "2530169917252",
+        "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+      },
+      "images": [
+        "https://cdn.dummyjson.com/product-images/groceries/kiwi/1.webp"
+      ],
+      "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/kiwi/thumbnail.webp"
+    }
+  ],
+  "total": 194,
+  "skip": 0,
+  "limit": 30
+}


### PR DESCRIPTION
Las imágenes de las URL antiguas ya no existen en el servidor, y cuando se hace la petición, ejemplo: https://cdn.dummyjson.com/product-images/1/thumbnail.jpg, devuelve esto:
<div align="center">
<img src="https://github.com/user-attachments/assets/1ae14818-b819-40c2-8e3b-e0539526303f" alt="thumbnail-obsoleto" width="100" align="center"/>
</div>


Así que actualicé el json para solucionarlo. El json obtiene los primeros 30 productos de la API. **No hay que preocuparse** por si cambiaron o eliminaron alguna de las propiedades que se usan en el curso (id, title, thumbnail, etc.) porque siguen estando, en todo caso agregaron más!